### PR TITLE
Threadblock部分の実装

### DIFF
--- a/iosTraining-Reeen.xcodeproj/project.pbxproj
+++ b/iosTraining-Reeen.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0D1566732A2EDA7F009A5927 /* WeatherViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1566722A2EDA7F009A5927 /* WeatherViewControllerTests.swift */; };
 		0D15668D2A2EF99D009A5927 /* YumemiWeather in Frameworks */ = {isa = PBXBuildFile; productRef = 0D15668C2A2EF99D009A5927 /* YumemiWeather */; };
 		0D1566902A2EFC47009A5927 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0D15668F2A2EFC47009A5927 /* SnapKit */; };
+		0DA1BA8E2A775947000519E6 /* DecodeAndEncodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA1BA8D2A775947000519E6 /* DecodeAndEncodeTests.swift */; };
 		0DA80A7B2A579D62005B7518 /* WeatherCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA80A772A579D62005B7518 /* WeatherCondition.swift */; };
 		0DA80A7C2A579D62005B7518 /* WeatherData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA80A782A579D62005B7518 /* WeatherData.swift */; };
 		0DA80A7D2A579D62005B7518 /* WeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA80A792A579D62005B7518 /* WeatherError.swift */; };
@@ -46,6 +47,7 @@
 		0D15666E2A2EDA7F009A5927 /* iosTraining-ReeenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iosTraining-ReeenTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D1566722A2EDA7F009A5927 /* WeatherViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherViewControllerTests.swift; sourceTree = "<group>"; };
 		0D64CA562A45304A00180ADD /* YumemiWeatherStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YumemiWeatherStub.swift; sourceTree = "<group>"; };
+		0DA1BA8D2A775947000519E6 /* DecodeAndEncodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodeAndEncodeTests.swift; sourceTree = "<group>"; };
 		0DA80A6D2A579CE9005B7518 /* WeatherViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeatherViewController.swift; sourceTree = "<group>"; };
 		0DA80A6E2A579CE9005B7518 /* ModalHolderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalHolderViewController.swift; sourceTree = "<group>"; };
 		0DA80A772A579D62005B7518 /* WeatherCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeatherCondition.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 		0D1566712A2EDA7F009A5927 /* iosTraining-ReeenTests */ = {
 			isa = PBXGroup;
 			children = (
+				0DA1BA8D2A775947000519E6 /* DecodeAndEncodeTests.swift */,
 				0D64CA562A45304A00180ADD /* YumemiWeatherStub.swift */,
 				0D1566722A2EDA7F009A5927 /* WeatherViewControllerTests.swift */,
 			);
@@ -289,6 +292,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D1566732A2EDA7F009A5927 /* WeatherViewControllerTests.swift in Sources */,
+				0DA1BA8E2A775947000519E6 /* DecodeAndEncodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosTraining-Reeen/Contoller/WeatherViewController.swift
+++ b/iosTraining-Reeen/Contoller/WeatherViewController.swift
@@ -52,9 +52,14 @@ private extension WeatherViewController {
 
     @objc func willEnterForeground() {
         if presentedViewController == nil {
-            weatherView.activityIndicator.startAnimating()
             weatherService.getWeatherInformation()
         }
+    }
+
+    func performData(_ weatherData: WeatherData?) {
+        guard let weatherData else { return }
+        let image = WeatherCondition(rawValue: weatherData.weatherCondition)?.getImage()
+        weatherView.displayWeatherConditions(data: weatherData, image: image)
     }
 }
 
@@ -62,13 +67,25 @@ extension WeatherViewController: WeatherViewDelegate {
     func weatherViewDidReloadButtonTapped(_ weatherView: WeatherView) {
         weatherService.getWeatherInformation()
     }
-    
+
     func weatherViewDidCloseButtonTapped(_ weatherView: WeatherView) {
         dismiss(animated: true, completion: nil)
     }
 }
 
 extension WeatherViewController: WeatherServiceDelegate {
+    func weatherServiceDidStartFetching(_ weatherService: WeatherServiceProtocol) {
+        DispatchQueue.main.async {
+            self.weatherView.activityIndicator.startAnimating()
+        }
+    }
+    
+    func weatherServiceDidEndFetching(_ weatherService: WeatherServiceProtocol) {
+        DispatchQueue.main.async {
+            self.weatherView.activityIndicator.stopAnimating()
+        }
+    }
+    
     func weatherService(_ weatherService: WeatherServiceProtocol, didUpdateCondition weatherData: WeatherData) {
         DispatchQueue.main.async { [weak self] in
             let image = WeatherCondition(rawValue: weatherData.weatherCondition)?.getImage()
@@ -83,7 +100,6 @@ extension WeatherViewController: WeatherServiceDelegate {
             let alertAction = UIAlertAction(title: "OK", style: .default)
             errorAlert.addAction(alertAction)
             self?.present(errorAlert, animated: true)
-            self?.weatherView.activityIndicator.stopAnimating()
         }
     }
 }

--- a/iosTraining-Reeen/Contoller/WeatherViewController.swift
+++ b/iosTraining-Reeen/Contoller/WeatherViewController.swift
@@ -74,10 +74,12 @@ extension WeatherViewController: WeatherServiceDelegate {
     }
 
     func weatherService(_ weatherService: WeatherServiceProtocol, didFailWithError error: Error) {
-        let errorAlert = UIAlertController(title: "Alert", message: error.localizedDescription, preferredStyle: .alert)
-        let alertAction = UIAlertAction(title: "OK", style: .default)
-        errorAlert.addAction(alertAction)
-        present(errorAlert, animated: true)
+        DispatchQueue.main.async {
+            let errorAlert = UIAlertController(title: "Alert", message: error.localizedDescription, preferredStyle: .alert)
+            let alertAction = UIAlertAction(title: "OK", style: .default)
+            errorAlert.addAction(alertAction)
+            self.present(errorAlert, animated: true)
+        }
     }
 }
 
@@ -93,3 +95,4 @@ private extension WeatherCondition {
         }
     }
 }
+

--- a/iosTraining-Reeen/Contoller/WeatherViewController.swift
+++ b/iosTraining-Reeen/Contoller/WeatherViewController.swift
@@ -55,12 +55,6 @@ private extension WeatherViewController {
             weatherService.getWeatherInformation()
         }
     }
-
-    func performData(_ weatherData: WeatherData?) {
-        guard let weatherData else { return }
-        let image = WeatherCondition(rawValue: weatherData.weatherCondition)?.getImage()
-        weatherView.displayWeatherConditions(data: weatherData, image: image)
-    }
 }
 
 extension WeatherViewController: WeatherViewDelegate {

--- a/iosTraining-Reeen/Contoller/WeatherViewController.swift
+++ b/iosTraining-Reeen/Contoller/WeatherViewController.swift
@@ -74,7 +74,7 @@ extension WeatherViewController: WeatherViewDelegate {
 }
 
 extension WeatherViewController: WeatherServiceDelegate {
-    func weatherServiceDidStartFetching(_ weatherService: WeatherServiceProtocol) {
+    func weatherServiceWillStartFetching(_ weatherService: WeatherServiceProtocol) {
         DispatchQueue.main.async {
             self.weatherView.activityIndicator.startAnimating()
         }

--- a/iosTraining-Reeen/Contoller/WeatherViewController.swift
+++ b/iosTraining-Reeen/Contoller/WeatherViewController.swift
@@ -69,14 +69,14 @@ extension WeatherViewController: WeatherViewDelegate {
 
 extension WeatherViewController: WeatherServiceDelegate {
     func weatherServiceWillStartFetching(_ weatherService: WeatherServiceProtocol) {
-        DispatchQueue.main.async {
-            self.weatherView.activityIndicator.startAnimating()
+        DispatchQueue.main.async { [weak self] in
+            self?.weatherView.activityIndicator.startAnimating()
         }
     }
     
     func weatherServiceDidEndFetching(_ weatherService: WeatherServiceProtocol) {
-        DispatchQueue.main.async {
-            self.weatherView.activityIndicator.stopAnimating()
+        DispatchQueue.main.async { [weak self] in
+            self?.weatherView.activityIndicator.stopAnimating()
         }
     }
     
@@ -85,7 +85,6 @@ extension WeatherViewController: WeatherServiceDelegate {
             guard let self else { return }
             let image = WeatherCondition(rawValue: weatherData.weatherCondition)?.getImage()
             self.weatherView.displayWeatherConditions(data: weatherData, image: image)
-            self.weatherView.activityIndicator.stopAnimating()
         }
     }
 

--- a/iosTraining-Reeen/Contoller/WeatherViewController.swift
+++ b/iosTraining-Reeen/Contoller/WeatherViewController.swift
@@ -52,6 +52,7 @@ private extension WeatherViewController {
 
     @objc func willEnterForeground() {
         if presentedViewController == nil {
+            weatherView.activityIndicator.startAnimating()
             weatherService.getWeatherInformation()
         }
     }
@@ -69,16 +70,20 @@ extension WeatherViewController: WeatherViewDelegate {
 
 extension WeatherViewController: WeatherServiceDelegate {
     func weatherService(_ weatherService: WeatherServiceProtocol, didUpdateCondition weatherData: WeatherData) {
-        let image = WeatherCondition(rawValue: weatherData.weatherCondition)?.getImage()
-        weatherView.displayWeatherConditions(data: weatherData, image: image)
+        DispatchQueue.main.async { [weak self] in
+            let image = WeatherCondition(rawValue: weatherData.weatherCondition)?.getImage()
+            self?.weatherView.displayWeatherConditions(data: weatherData, image: image)
+            self?.weatherView.activityIndicator.stopAnimating()
+        }
     }
 
     func weatherService(_ weatherService: WeatherServiceProtocol, didFailWithError error: Error) {
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
             let errorAlert = UIAlertController(title: "Alert", message: error.localizedDescription, preferredStyle: .alert)
             let alertAction = UIAlertAction(title: "OK", style: .default)
             errorAlert.addAction(alertAction)
-            self.present(errorAlert, animated: true)
+            self?.present(errorAlert, animated: true)
+            self?.weatherView.activityIndicator.stopAnimating()
         }
     }
 }

--- a/iosTraining-Reeen/Contoller/WeatherViewController.swift
+++ b/iosTraining-Reeen/Contoller/WeatherViewController.swift
@@ -88,18 +88,20 @@ extension WeatherViewController: WeatherServiceDelegate {
     
     func weatherService(_ weatherService: WeatherServiceProtocol, didUpdateCondition weatherData: WeatherData) {
         DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
             let image = WeatherCondition(rawValue: weatherData.weatherCondition)?.getImage()
-            self?.weatherView.displayWeatherConditions(data: weatherData, image: image)
-            self?.weatherView.activityIndicator.stopAnimating()
+            self.weatherView.displayWeatherConditions(data: weatherData, image: image)
+            self.weatherView.activityIndicator.stopAnimating()
         }
     }
 
     func weatherService(_ weatherService: WeatherServiceProtocol, didFailWithError error: Error) {
         DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
             let errorAlert = UIAlertController(title: "Alert", message: error.localizedDescription, preferredStyle: .alert)
             let alertAction = UIAlertAction(title: "OK", style: .default)
             errorAlert.addAction(alertAction)
-            self?.present(errorAlert, animated: true)
+            self.present(errorAlert, animated: true)
         }
     }
 }

--- a/iosTraining-Reeen/Model/WeatherService.swift
+++ b/iosTraining-Reeen/Model/WeatherService.swift
@@ -24,13 +24,15 @@ final class WeatherService: WeatherServiceProtocol {
     weak var delegate: WeatherServiceDelegate?
 
     func getWeatherInformation() {
-        do {
-            let encodedRequest = try WeatherEncoder.encodeRequestParameters(.init(area: "tokyo", date: Date()))
-            let weatherInfo = try YumemiWeather.fetchWeather(encodedRequest)
-            let weatherData = try WeatherDecoder.decodeWeatherInfo(weatherInfo)
-            delegate?.weatherService(self, didUpdateCondition: weatherData)
-        } catch {
-            handleWeatherServiceError(error)
+        DispatchQueue.global(qos: .background).async {
+            do {
+                let encodedRequest = try WeatherEncoder.encodeRequestParameters(.init(area: "tokyo", date: Date()))
+                let weatherInfo = try YumemiWeather.syncFetchWeather(encodedRequest)
+                let weatherData = try WeatherDecoder.decodeWeatherInfo(weatherInfo)
+                self.delegate?.weatherService(self, didUpdateCondition: weatherData)
+            } catch {
+                self.handleWeatherServiceError(error)
+            }
         }
     }
 }

--- a/iosTraining-Reeen/Model/WeatherService.swift
+++ b/iosTraining-Reeen/Model/WeatherService.swift
@@ -29,15 +29,16 @@ final class WeatherService: WeatherServiceProtocol {
         delegate?.weatherServiceWillStartFetching(self)
         DispatchQueue.global().async { [weak self] in
             guard let self else { return }
+            defer {
+                self.delegate?.weatherServiceDidEndFetching(self)
+            }
             do {
                 let encodedRequest = try WeatherEncoder.encodeRequestParameters(.init(area: "tokyo", date: Date()))
                 let weatherInfo = try YumemiWeather.syncFetchWeather(encodedRequest)
                 let weatherData = try WeatherDecoder.decodeWeatherInfo(weatherInfo)
                 self.delegate?.weatherService(self, didUpdateCondition: weatherData)
-                delegate?.weatherServiceDidEndFetching(self)
             } catch {
                 self.handleWeatherServiceError(error)
-                delegate?.weatherServiceDidEndFetching(self)
             }
         }
     }

--- a/iosTraining-Reeen/Model/WeatherService.swift
+++ b/iosTraining-Reeen/Model/WeatherService.swift
@@ -15,7 +15,7 @@ protocol WeatherServiceProtocol: AnyObject {
 }
 
 protocol WeatherServiceDelegate: AnyObject {
-    func weatherServiceDidStartFetching(_ weatherService: WeatherServiceProtocol)
+    func weatherServiceWillStartFetching(_ weatherService: WeatherServiceProtocol)
     func weatherServiceDidEndFetching(_ weatherService: WeatherServiceProtocol)
     func weatherService(_ weatherService: WeatherServiceProtocol, didUpdateCondition weatherInfo: WeatherData)
     func weatherService(_ weatherService: WeatherServiceProtocol, didFailWithError error: Error)
@@ -26,7 +26,7 @@ final class WeatherService: WeatherServiceProtocol {
     weak var delegate: WeatherServiceDelegate?
 
     func getWeatherInformation() {
-        delegate?.weatherServiceDidStartFetching(self)
+        delegate?.weatherServiceWillStartFetching(self)
         DispatchQueue.global().async { [weak self] in
             guard let self else { return }
             do {

--- a/iosTraining-Reeen/Model/WeatherService.swift
+++ b/iosTraining-Reeen/Model/WeatherService.swift
@@ -27,7 +27,7 @@ final class WeatherService: WeatherServiceProtocol {
 
     func getWeatherInformation() {
         delegate?.weatherServiceDidStartFetching(self)
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global().async { [weak self] in
             guard let self else { return }
             do {
                 let encodedRequest = try WeatherEncoder.encodeRequestParameters(.init(area: "tokyo", date: Date()))

--- a/iosTraining-Reeen/View/WeatherView.swift
+++ b/iosTraining-Reeen/View/WeatherView.swift
@@ -66,6 +66,7 @@ final class WeatherView: UIView {
     }()
 
     weak var weatherViewDelegate: WeatherViewDelegate?
+
     let activityIndicator = UIActivityIndicatorView(style: .medium)
 
     override init(frame: CGRect) {

--- a/iosTraining-Reeen/View/WeatherView.swift
+++ b/iosTraining-Reeen/View/WeatherView.swift
@@ -67,8 +67,6 @@ final class WeatherView: UIView {
 
     weak var weatherViewDelegate: WeatherViewDelegate?
 
-    let activityIndicator = UIActivityIndicatorView(style: .medium)
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
@@ -91,7 +89,6 @@ private extension WeatherView {
         addSubview(weatherConditionStackView)
         addSubview(closeButton)
         addSubview(reloadButton)
-        addSubview(activityIndicator)
 
         reloadButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
@@ -121,11 +118,6 @@ private extension WeatherView {
             make.centerX.equalTo(minTemperatureLabel)
             make.top.equalTo(minTemperatureLabel.snp.centerY).offset(80)
             make.width.equalTo(minTemperatureLabel.snp.width)
-        }
-
-        activityIndicator.snp.makeConstraints { make in
-            make.centerY.equalTo(maxTemperatureLabel.snp.centerY).offset(50)
-            make.centerX.equalToSuperview()
         }
     }
 }

--- a/iosTraining-Reeen/View/WeatherView.swift
+++ b/iosTraining-Reeen/View/WeatherView.swift
@@ -66,6 +66,7 @@ final class WeatherView: UIView {
     }()
 
     weak var weatherViewDelegate: WeatherViewDelegate?
+    let activityIndicator = UIActivityIndicatorView(style: .medium)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -89,6 +90,7 @@ private extension WeatherView {
         addSubview(weatherConditionStackView)
         addSubview(closeButton)
         addSubview(reloadButton)
+        addSubview(activityIndicator)
 
         reloadButton.addAction(UIAction { [weak self] _ in
             guard let self else { return }
@@ -118,6 +120,11 @@ private extension WeatherView {
             make.centerX.equalTo(minTemperatureLabel)
             make.top.equalTo(minTemperatureLabel.snp.centerY).offset(80)
             make.width.equalTo(minTemperatureLabel.snp.width)
+        }
+
+        activityIndicator.snp.makeConstraints { make in
+            make.centerY.equalTo(maxTemperatureLabel.snp.centerY).offset(50)
+            make.centerX.equalToSuperview()
         }
     }
 }

--- a/iosTraining-ReeenTests/WeatherViewControllerTests.swift
+++ b/iosTraining-ReeenTests/WeatherViewControllerTests.swift
@@ -30,12 +30,12 @@ final class WeatherViewControllerTests: XCTestCase {
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "sunny")?.withTintColor(.red))
             self.expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 0.2)
+        wait(for: [expectation], timeout: 0.1)
     }
 
     func testWeatherConditionImageViewIsRainy() throws {
@@ -46,12 +46,12 @@ final class WeatherViewControllerTests: XCTestCase {
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "rainy")?.withTintColor(.blue))
             self.expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 0.2)
+        wait(for: [expectation], timeout: 0.1)
     }
 
     func testWeatherConditionImageViewIsCloudy() throws {
@@ -62,12 +62,12 @@ final class WeatherViewControllerTests: XCTestCase {
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "cloudy")?.withTintColor(.gray))
             self.expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 0.2)
+        wait(for: [expectation], timeout: 0.1)
     }
 
     func testTempLabelShowAsExpected() throws {
@@ -78,14 +78,14 @@ final class WeatherViewControllerTests: XCTestCase {
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
             let maxTempLabel = self.weatherViewController.weatherView.maxTemperatureLabel.text
             let mimTempLabel = self.weatherViewController.weatherView.minTemperatureLabel.text
             XCTAssertEqual(maxTempLabel, "20")
             XCTAssertEqual(mimTempLabel, "10")
             self.expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 0.2)
+        wait(for: [expectation], timeout: 0.1)
 
     }
 }

--- a/iosTraining-ReeenTests/WeatherViewControllerTests.swift
+++ b/iosTraining-ReeenTests/WeatherViewControllerTests.swift
@@ -30,12 +30,12 @@ final class WeatherViewControllerTests: XCTestCase {
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "sunny")?.withTintColor(.red))
             self.expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 0.2)
     }
 
     func testWeatherConditionImageViewIsRainy() throws {
@@ -46,12 +46,12 @@ final class WeatherViewControllerTests: XCTestCase {
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "rainy")?.withTintColor(.blue))
             self.expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 0.2)
     }
 
     func testWeatherConditionImageViewIsCloudy() throws {
@@ -62,12 +62,12 @@ final class WeatherViewControllerTests: XCTestCase {
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "cloudy")?.withTintColor(.gray))
             self.expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 0.2)
     }
 
     func testTempLabelShowAsExpected() throws {
@@ -78,14 +78,14 @@ final class WeatherViewControllerTests: XCTestCase {
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             let maxTempLabel = self.weatherViewController.weatherView.maxTemperatureLabel.text
             let mimTempLabel = self.weatherViewController.weatherView.minTemperatureLabel.text
             XCTAssertEqual(maxTempLabel, "20")
             XCTAssertEqual(mimTempLabel, "10")
             self.expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 0.2)
 
     }
 }

--- a/iosTraining-ReeenTests/WeatherViewControllerTests.swift
+++ b/iosTraining-ReeenTests/WeatherViewControllerTests.swift
@@ -20,62 +20,73 @@ extension WeatherData {
 
 final class WeatherViewControllerTests: XCTestCase {
     var weatherViewController: WeatherViewController!
+    let expectation = XCTestExpectation(description: "Wait for weather data to update")
 
-    func testWeatherConditionImageViewIsSunny() {
+    func testWeatherConditionImageViewIsSunny() throws {
         // Arrange
-        DispatchQueue.main.async {
-            let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "sunny"))
-            self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
-            self.weatherViewController.loadViewIfNeeded()
-            // Act
-            self.weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
-            // Assert
+        let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "sunny"))
+        weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+        weatherViewController.loadViewIfNeeded()
+        weatherDataStub.delegate = weatherViewController
+        // Act
+        weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+        // Assert
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "sunny")?.withTintColor(.red))
+            self.expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 2.0)
     }
 
-    func testWeatherConditionImageViewIsRainy() {
+    func testWeatherConditionImageViewIsRainy() throws {
         // Arrange
-        DispatchQueue.main.async {
-            let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "rainy"))
-            self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
-            self.weatherViewController.loadViewIfNeeded()
-            // Act
-            self.weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
-            // Assert
+        let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "rainy"))
+        self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+        weatherViewController.loadViewIfNeeded()
+        // Act
+        weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+        // Assert
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "rainy")?.withTintColor(.blue))
+            self.expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 2.0)
     }
 
-    func testWeatherConditionImageViewIsCloudy() {
+    func testWeatherConditionImageViewIsCloudy() throws {
         // Arrange
-        DispatchQueue.main.async {
-            let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "cloudy"))
-            self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
-            self.weatherViewController.loadViewIfNeeded()
-            // Act
-            self.weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
-            // Assert
+        let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "cloudy"))
+        self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+        weatherViewController.loadViewIfNeeded()
+        // Act
+        weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+        // Assert
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
             XCTAssertEqual(weatherConditionImageView, UIImage(named: "cloudy")?.withTintColor(.gray))
+            self.expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 2.0)
     }
 
-    func testTempLabelShowAsExpected() {
+    func testTempLabelShowAsExpected() throws {
         // Arrange
-        DispatchQueue.main.async {
-            let weatherDataStub = YumemiWeatherStub(weatherData: .init(maxTemperature: 20, minTemperature: 10))
-            self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
-            self.weatherViewController.loadViewIfNeeded()
-            // Act
-            self.weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
-            // Assert
+        let weatherDataStub = YumemiWeatherStub(weatherData: .init(maxTemperature: 20, minTemperature: 10))
+        self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+        weatherViewController.loadViewIfNeeded()
+        // Act
+        weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+        // Assert
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             let maxTempLabel = self.weatherViewController.weatherView.maxTemperatureLabel.text
             let mimTempLabel = self.weatherViewController.weatherView.minTemperatureLabel.text
             XCTAssertEqual(maxTempLabel, "20")
             XCTAssertEqual(mimTempLabel, "10")
+            self.expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 2.0)
+
     }
 }

--- a/iosTraining-ReeenTests/WeatherViewControllerTests.swift
+++ b/iosTraining-ReeenTests/WeatherViewControllerTests.swift
@@ -21,53 +21,61 @@ extension WeatherData {
 final class WeatherViewControllerTests: XCTestCase {
     var weatherViewController: WeatherViewController!
 
-    func testWeatherConditionImageViewIsSunny() async throws {
+    func testWeatherConditionImageViewIsSunny() {
         // Arrange
-        let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "sunny"))
-        weatherViewController = await WeatherViewController(weatherService: weatherDataStub)
-        await weatherViewController.loadViewIfNeeded()
-        // Act
-        await weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
-        // Assert
-        let weatherConditionImageView = await weatherViewController.weatherView.weatherConditionImageView.image
-        XCTAssertEqual(weatherConditionImageView, UIImage(named: "sunny")?.withTintColor(.red))
+        DispatchQueue.main.async {
+            let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "sunny"))
+            self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+            self.weatherViewController.loadViewIfNeeded()
+            // Act
+            self.weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+            // Assert
+            let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
+            XCTAssertEqual(weatherConditionImageView, UIImage(named: "sunny")?.withTintColor(.red))
+        }
     }
 
-    func testWeatherConditionImageViewIsRainy() async throws {
+    func testWeatherConditionImageViewIsRainy() {
         // Arrange
-        let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "rainy"))
-        weatherViewController = await WeatherViewController(weatherService: weatherDataStub)
-        await weatherViewController.loadViewIfNeeded()
-        // Act
-        await weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
-        // Assert
-        let weatherConditionImageView = await weatherViewController.weatherView.weatherConditionImageView.image
-        XCTAssertEqual(weatherConditionImageView, UIImage(named: "rainy")?.withTintColor(.blue))
+        DispatchQueue.main.async {
+            let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "rainy"))
+            self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+            self.weatherViewController.loadViewIfNeeded()
+            // Act
+            self.weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+            // Assert
+            let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
+            XCTAssertEqual(weatherConditionImageView, UIImage(named: "rainy")?.withTintColor(.blue))
+        }
     }
 
-    func testWeatherConditionImageViewIsCloudy() async throws {
+    func testWeatherConditionImageViewIsCloudy() {
         // Arrange
-        let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "cloudy"))
-        weatherViewController = await WeatherViewController(weatherService: weatherDataStub)
-        await weatherViewController.loadViewIfNeeded()
-        // Act
-        await weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
-        // Assert
-        let weatherConditionImageView = await weatherViewController.weatherView.weatherConditionImageView.image
-        XCTAssertEqual(weatherConditionImageView, UIImage(named: "cloudy")?.withTintColor(.gray))
+        DispatchQueue.main.async {
+            let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "cloudy"))
+            self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+            self.weatherViewController.loadViewIfNeeded()
+            // Act
+            self.weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+            // Assert
+            let weatherConditionImageView = self.weatherViewController.weatherView.weatherConditionImageView.image
+            XCTAssertEqual(weatherConditionImageView, UIImage(named: "cloudy")?.withTintColor(.gray))
+        }
     }
 
-    func testTempLabelShowAsExpected() async throws {
+    func testTempLabelShowAsExpected() {
         // Arrange
-        let weatherDataStub = YumemiWeatherStub(weatherData: .init(maxTemperature: 20, minTemperature: 10))
-        weatherViewController = await WeatherViewController(weatherService: weatherDataStub)
-        await weatherViewController.loadViewIfNeeded()
-        // Act
-        await weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
-        // Assert
-        let maxTempLabel = await weatherViewController.weatherView.maxTemperatureLabel.text
-        let mimTempLabel = await weatherViewController.weatherView.minTemperatureLabel.text
-        XCTAssertEqual(maxTempLabel, "20")
-        XCTAssertEqual(mimTempLabel, "10")
+        DispatchQueue.main.async {
+            let weatherDataStub = YumemiWeatherStub(weatherData: .init(maxTemperature: 20, minTemperature: 10))
+            self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+            self.weatherViewController.loadViewIfNeeded()
+            // Act
+            self.weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+            // Assert
+            let maxTempLabel = self.weatherViewController.weatherView.maxTemperatureLabel.text
+            let mimTempLabel = self.weatherViewController.weatherView.minTemperatureLabel.text
+            XCTAssertEqual(maxTempLabel, "20")
+            XCTAssertEqual(mimTempLabel, "10")
+        }
     }
 }

--- a/iosTraining-ReeenTests/WeatherViewControllerTests.swift
+++ b/iosTraining-ReeenTests/WeatherViewControllerTests.swift
@@ -42,7 +42,7 @@ final class WeatherViewControllerTests: XCTestCase {
     func testWeatherConditionImageViewIsRainy() throws {
         // Arrange
         let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "rainy"))
-        self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+        weatherViewController = WeatherViewController(weatherService: weatherDataStub)
         weatherViewController.loadViewIfNeeded()
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
@@ -58,7 +58,7 @@ final class WeatherViewControllerTests: XCTestCase {
     func testWeatherConditionImageViewIsCloudy() throws {
         // Arrange
         let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "cloudy"))
-        self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+        weatherViewController = WeatherViewController(weatherService: weatherDataStub)
         weatherViewController.loadViewIfNeeded()
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
@@ -74,7 +74,7 @@ final class WeatherViewControllerTests: XCTestCase {
     func testTempLabelShowAsExpected() throws {
         // Arrange
         let weatherDataStub = YumemiWeatherStub(weatherData: .init(maxTemperature: 20, minTemperature: 10))
-        self.weatherViewController = WeatherViewController(weatherService: weatherDataStub)
+        weatherViewController = WeatherViewController(weatherService: weatherDataStub)
         weatherViewController.loadViewIfNeeded()
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)

--- a/iosTraining-ReeenTests/WeatherViewControllerTests.swift
+++ b/iosTraining-ReeenTests/WeatherViewControllerTests.swift
@@ -21,52 +21,52 @@ extension WeatherData {
 final class WeatherViewControllerTests: XCTestCase {
     var weatherViewController: WeatherViewController!
 
-    func testWeatherConditionImageViewIsSunny() {
+    func testWeatherConditionImageViewIsSunny() async throws {
         // Arrange
         let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "sunny"))
-        weatherViewController = WeatherViewController(weatherService: weatherDataStub)
-        weatherViewController.loadViewIfNeeded()
+        weatherViewController = await WeatherViewController(weatherService: weatherDataStub)
+        await weatherViewController.loadViewIfNeeded()
         // Act
-        weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+        await weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        let weatherConditionImageView = weatherViewController.weatherView.weatherConditionImageView.image
+        let weatherConditionImageView = await weatherViewController.weatherView.weatherConditionImageView.image
         XCTAssertEqual(weatherConditionImageView, UIImage(named: "sunny")?.withTintColor(.red))
     }
 
-    func testWeatherConditionImageViewIsRainy() {
+    func testWeatherConditionImageViewIsRainy() async throws {
         // Arrange
         let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "rainy"))
-        weatherViewController = WeatherViewController(weatherService: weatherDataStub)
-        weatherViewController.loadViewIfNeeded()
+        weatherViewController = await WeatherViewController(weatherService: weatherDataStub)
+        await weatherViewController.loadViewIfNeeded()
         // Act
-        weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+        await weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        let weatherConditionImageView = weatherViewController.weatherView.weatherConditionImageView.image
+        let weatherConditionImageView = await weatherViewController.weatherView.weatherConditionImageView.image
         XCTAssertEqual(weatherConditionImageView, UIImage(named: "rainy")?.withTintColor(.blue))
     }
 
-    func testWeatherConditionImageViewIsCloudy() {
+    func testWeatherConditionImageViewIsCloudy() async throws {
         // Arrange
         let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "cloudy"))
-        weatherViewController = WeatherViewController(weatherService: weatherDataStub)
-        weatherViewController.loadViewIfNeeded()
+        weatherViewController = await WeatherViewController(weatherService: weatherDataStub)
+        await weatherViewController.loadViewIfNeeded()
         // Act
-        weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+        await weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        let weatherConditionImageView = weatherViewController.weatherView.weatherConditionImageView.image
+        let weatherConditionImageView = await weatherViewController.weatherView.weatherConditionImageView.image
         XCTAssertEqual(weatherConditionImageView, UIImage(named: "cloudy")?.withTintColor(.gray))
     }
 
-    func testTempLabelShowAsExpected() {
+    func testTempLabelShowAsExpected() async throws {
         // Arrange
         let weatherDataStub = YumemiWeatherStub(weatherData: .init(maxTemperature: 20, minTemperature: 10))
-        weatherViewController = WeatherViewController(weatherService: weatherDataStub)
-        weatherViewController.loadViewIfNeeded()
+        weatherViewController = await WeatherViewController(weatherService: weatherDataStub)
+        await weatherViewController.loadViewIfNeeded()
         // Act
-        weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
+        await weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert
-        let maxTempLabel = weatherViewController.weatherView.maxTemperatureLabel.text
-        let mimTempLabel = weatherViewController.weatherView.minTemperatureLabel.text
+        let maxTempLabel = await weatherViewController.weatherView.maxTemperatureLabel.text
+        let mimTempLabel = await weatherViewController.weatherView.minTemperatureLabel.text
         XCTAssertEqual(maxTempLabel, "20")
         XCTAssertEqual(mimTempLabel, "10")
     }

--- a/iosTraining-ReeenTests/WeatherViewControllerTests.swift
+++ b/iosTraining-ReeenTests/WeatherViewControllerTests.swift
@@ -27,7 +27,6 @@ final class WeatherViewControllerTests: XCTestCase {
         let weatherDataStub = YumemiWeatherStub(weatherData: .init(weatherCondition: "sunny"))
         weatherViewController = WeatherViewController(weatherService: weatherDataStub)
         weatherViewController.loadViewIfNeeded()
-        weatherDataStub.delegate = weatherViewController
         // Act
         weatherViewController.weatherView.reloadButton.sendActions(for: .touchUpInside)
         // Assert


### PR DESCRIPTION
### 動作映像
https://github.com/yumemi-inc/iosTraining-Reeen/assets/94460967/c690e3f9-5b90-44f2-84e8-089f039b4d5d

### 変更点
- APIを`syncFetchWeather`に変更
- テストを非同期に対応
- UIの更新をメインスレッドで行うように変更

### 備考
- https://github.com/yumemi-inc/ios-training/blob/main/Documentation/ThreadBlock.md
- Xcode15-0-0-Betaでの実装